### PR TITLE
Replace os.OpenFile with unix.Open to avoid blocking write operations

### DIFF
--- a/webcam.go
+++ b/webcam.go
@@ -6,14 +6,13 @@ package webcam
 import (
 	"errors"
 	"golang.org/x/sys/unix"
-	"os"
 	"reflect"
 	"unsafe"
 )
 
 // Webcam object
 type Webcam struct {
-	file    *os.File
+	//file    *os.File
 	fd      uintptr
 	buffers [][]byte
 }
@@ -23,8 +22,8 @@ type Webcam struct {
 // capable to stream video
 func Open(path string) (*Webcam, error) {
 
-	file, err := os.OpenFile(path, unix.O_RDWR|unix.O_NONBLOCK, 0666)
-	fd := file.Fd()
+	file, err := unix.Open(path, unix.O_RDWR|unix.O_NONBLOCK, 0666)
+	fd := uintptr(file)
 
 	if fd < 0 || err != nil {
 		return nil, err
@@ -46,7 +45,7 @@ func Open(path string) (*Webcam, error) {
 
 	w := new(Webcam)
 	w.fd = fd
-	w.file = file
+	//w.file = file
 	return w, nil
 }
 
@@ -218,7 +217,7 @@ func (w *Webcam) Close() error {
 		}
 	}
 
-	err := w.file.Close()
+	err := unix.Close(w.fd)
 
 	return err
 }

--- a/webcam.go
+++ b/webcam.go
@@ -12,7 +12,6 @@ import (
 
 // Webcam object
 type Webcam struct {
-	//file    *os.File
 	fd      uintptr
 	buffers [][]byte
 }
@@ -22,8 +21,8 @@ type Webcam struct {
 // capable to stream video
 func Open(path string) (*Webcam, error) {
 
-	file, err := unix.Open(path, unix.O_RDWR|unix.O_NONBLOCK, 0666)
-	fd := uintptr(file)
+	handle, err := unix.Open(path, unix.O_RDWR|unix.O_NONBLOCK, 0666)
+	fd := uintptr(handle)
 
 	if fd < 0 || err != nil {
 		return nil, err
@@ -44,8 +43,7 @@ func Open(path string) (*Webcam, error) {
 	}
 
 	w := new(Webcam)
-	w.fd = fd
-	//w.file = file
+	w.fd = uintptr(fd)
 	return w, nil
 }
 
@@ -217,7 +215,7 @@ func (w *Webcam) Close() error {
 		}
 	}
 
-	err := unix.Close(w.fd)
+	err := unix.Close(int(w.fd))
 
 	return err
 }


### PR DESCRIPTION
Solves Issue #14 

I have ave not extensively tested yet but these are the suggested changes for your review. 

## To Check:
I updated webcam.Close to use the `int = unix.Close(fd)` (we don't have the `*os.File` anymore). I believe this is the only spot to close the file?