### PR TITLE
Actually use values supplied by -s in webcam.go

### DIFF
--- a/examples/http_mjpeg_streamer/webcam.go
+++ b/examples/http_mjpeg_streamer/webcam.go
@@ -109,6 +109,7 @@ FMT:
 		for _, f := range frames {
 			if *szstr == f.GetString() {
 				size = &f
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Before this patch:

```
./webcam -s 640x480
Available formats:
YUYV 4:2:2
Motion-JPEG
Supported frame sizes for format YUYV 4:2:2
320x240
352x288
424x240
640x360
640x480
800x448
960x540
1280x720
Requesting YUYV 4:2:2 1280x720
Resulting image format: YUYV 4:2:2 1280x720
```

After this patch:
```
./webcam -s 640x480
(...)
Resulting image format: YUYV 4:2:2 640x480

```