### PR TITLE
add support for VIDIOC_G_INPUT and VIDIOC_S_INPUT

### DIFF
--- a/v4l2.go
+++ b/v4l2.go
@@ -84,6 +84,8 @@ var (
 	//sizeof int32
 	VIDIOC_STREAMON        = ioctl.IoW(uintptr('V'), 18, 4)
 	VIDIOC_STREAMOFF       = ioctl.IoW(uintptr('V'), 19, 4)
+	VIDIOC_G_INPUT         = ioctl.IoR(uintptr('V'), 38, 4)
+	VIDIOC_S_INPUT         = ioctl.IoRW(uintptr('V'), 39, 4)
 	VIDIOC_ENUM_FRAMESIZES = ioctl.IoRW(uintptr('V'), 74, unsafe.Sizeof(v4l2_frmsizeenum{}))
 	__p                    = unsafe.Pointer(uintptr(0))
 	NativeByteOrder        = getNativeByteOrder()
@@ -130,7 +132,7 @@ type v4l2_frmsize_stepwise struct {
 	Step_height uint32
 }
 
-//Hack to make go compiler properly align union
+// Hack to make go compiler properly align union
 type v4l2_format_aligned_union struct {
 	data [200 - unsafe.Sizeof(__p)]byte
 	_    unsafe.Pointer
@@ -487,6 +489,16 @@ func setControl(fd uintptr, id uint32, val int32) error {
 	ctrl.id = id
 	ctrl.value = val
 	return ioctl.Ioctl(fd, VIDIOC_S_CTRL, uintptr(unsafe.Pointer(ctrl)))
+}
+
+func getInput(fd uintptr) (index int32, err error) {
+	err = ioctl.Ioctl(fd, VIDIOC_G_INPUT, uintptr(unsafe.Pointer(&index)))
+	return
+}
+
+func selectInput(fd uintptr, index uint32) (err error) {
+	err = ioctl.Ioctl(fd, VIDIOC_S_INPUT, uintptr(unsafe.Pointer(&index)))
+	return
 }
 
 func getFramerate(fd uintptr) (float32, error) {

--- a/webcam.go
+++ b/webcam.go
@@ -86,7 +86,7 @@ func (w *Webcam) GetSupportedFormats() map[PixelFormat]string {
 	return result
 }
 
-// Select the current video input
+// SelectInput selects the current video input.
 func (w *Webcam) SelectInput(index uint32) error {
 	return selectInput(w.fd, index)
 }

--- a/webcam.go
+++ b/webcam.go
@@ -54,7 +54,7 @@ func Open(path string) (*Webcam, error) {
 	}
 
 	w := new(Webcam)
-	w.fd = uintptr(fd)
+	w.fd = fd
 	w.bufcount = 256
 	return w, nil
 }
@@ -84,6 +84,16 @@ func (w *Webcam) GetSupportedFormats() map[PixelFormat]string {
 	}
 
 	return result
+}
+
+// Select the current video input
+func (w *Webcam) SelectInput(index uint32) error {
+	return selectInput(w.fd, index)
+}
+
+// Query the current video input
+func (w *Webcam) GetInput() (int32, error) {
+	return getInput(w.fd)
 }
 
 // Returns supported frame sizes for a given image format

--- a/webcam.go
+++ b/webcam.go
@@ -91,7 +91,7 @@ func (w *Webcam) SelectInput(index uint32) error {
 	return selectInput(w.fd, index)
 }
 
-// Query the current video input
+// GetInput queries the current video input.
 func (w *Webcam) GetInput() (int32, error) {
 	return getInput(w.fd)
 }


### PR DESCRIPTION
This PR adds support for the `VIDIOC_G_INPUT` and `VIDIOC_S_INPUT` ioctls. At the very least this will allow users to query the status of their devices in real time since `VIDIOC_S_INPUT` is one of the few ioctls that return an `EBUSY` signal if in use.