### PR TITLE
Add GetSupportedFramerates

### DIFF
--- a/formats.go
+++ b/formats.go
@@ -22,6 +22,30 @@ type FrameSize struct {
 	StepHeight uint32
 }
 
+// FrameRate represents all possible framerates supported by a webcam
+// for a given pixel format and frame size. For discrete returns min
+// and max values will be the same and step value will be equal to '0'
+// Stepwise returns are represented as a range of values with a step.
+type FrameRate struct {
+	MinNumerator  uint32
+	MaxNumerator  uint32
+	StepNumerator uint32
+
+	MinDenominator  uint32
+	MaxDenominator  uint32
+	StepDenominator uint32
+}
+
+// Return string representation of FrameRate struct. e.g.1/30 for
+// discrete framerates and [1-2;1]/[10-60;1] for stepwise framerates.
+func (f FrameRate) String() string {
+	if f.StepNumerator == 0 && f.StepDenominator == 0 {
+		return fmt.Sprintf("%d/%d", f.MinNumerator, f.MinDenominator)
+	} else {
+		return fmt.Sprintf("[%d-%d;%d]/[%d-%d;%d]", f.MinNumerator, f.MaxNumerator, f.StepNumerator, f.MinDenominator, f.MaxDenominator, f.StepDenominator)
+	}
+}
+
 // Returns string representation of frame size, e.g.
 // 1280x720 for fixed-size frames and
 // [320-640;160]x[240-480;160] for stepwise-sized frames

--- a/webcam.go
+++ b/webcam.go
@@ -126,6 +126,26 @@ func (w *Webcam) GetSupportedFrameSizes(f PixelFormat) []FrameSize {
 	return result
 }
 
+// GetSupportedFramerates returns supported frame rates for a given image format and frame size.
+func (w *Webcam) GetSupportedFramerates(fp PixelFormat, width uint32, height uint32) []FrameRate {
+	var result []FrameRate
+	var index uint32
+	var err error
+
+	// keep incrementing the index value until we get an EINVAL error
+	index = 0
+	for err == nil {
+		r, err := getFrameInterval(w.fd, index, uint32(fp), width, height)
+		if err != nil {
+			break
+		}
+		result = append(result, r)
+		index++
+	}
+
+	return result
+}
+
 // Sets desired image format and frame size
 // Note, that device driver can change that values.
 // Resulting values are returned by a function


### PR DESCRIPTION
## GetSupportedFramerates

This PR allows for fetching the FPS settings of a camera driver for use in `setFramerate`. The code is similar to `GetSupportedFrameSizes`. 

An IOCTL constant `VIDIOC_ENUM_FRAMEINTERVALS` is added for making the system call, and a struct `FrameRate` is added as a container for the return.

`GetFrameInterval` makes the IOCTL call and parses the return. Much like FrameSizes, only `discrete` and `stepwise` returns are supported.
