### PR TITLE
expose device name and bus info

### DIFF
--- a/v4l2.go
+++ b/v4l2.go
@@ -323,7 +323,7 @@ func getName(fd uintptr) (string, error) {
 }
 
 func getBusInfo(fd uintptr) (string, error) {
-	caps := &v4l2_capability{}
+	var caps v4l2_capability
 	if err := ioctl.Ioctl(fd, VIDIOC_QUERYCAP, uintptr(unsafe.Pointer(caps))); err != nil {
 		return "", err
 	}

--- a/v4l2.go
+++ b/v4l2.go
@@ -130,7 +130,7 @@ type v4l2_frmsize_stepwise struct {
 	Step_height uint32
 }
 
-//Hack to make go compiler properly align union
+// Hack to make go compiler properly align union
 type v4l2_format_aligned_union struct {
 	data [200 - unsafe.Sizeof(__p)]byte
 	_    unsafe.Pointer
@@ -309,6 +309,24 @@ func getFrameSize(fd uintptr, index uint32, code uint32) (frameSize FrameSize, e
 	}
 
 	return
+}
+
+func getName(fd uintptr) (string, error) {
+	caps := &v4l2_capability{}
+	if err := ioctl.Ioctl(fd, VIDIOC_QUERYCAP, uintptr(unsafe.Pointer(caps))); err != nil {
+		return "", err
+	}
+
+	return CToGoString(caps.card[:]), nil
+}
+
+func getBusInfo(fd uintptr) (string, error) {
+	caps := &v4l2_capability{}
+	if err := ioctl.Ioctl(fd, VIDIOC_QUERYCAP, uintptr(unsafe.Pointer(caps))); err != nil {
+		return "", err
+	}
+
+	return CToGoString(caps.bus_info[:]), nil
 }
 
 func setImageFormat(fd uintptr, formatcode *uint32, width *uint32, height *uint32) (err error) {

--- a/v4l2.go
+++ b/v4l2.go
@@ -314,7 +314,7 @@ func getFrameSize(fd uintptr, index uint32, code uint32) (frameSize FrameSize, e
 }
 
 func getName(fd uintptr) (string, error) {
-	caps := &v4l2_capability{}
+	var caps v4l2_capability
 	if err := ioctl.Ioctl(fd, VIDIOC_QUERYCAP, uintptr(unsafe.Pointer(caps))); err != nil {
 		return "", err
 	}

--- a/webcam.go
+++ b/webcam.go
@@ -54,7 +54,7 @@ func Open(path string) (*Webcam, error) {
 	}
 
 	w := new(Webcam)
-	w.fd = uintptr(fd)
+	w.fd = fd
 	w.bufcount = 256
 	return w, nil
 }
@@ -84,6 +84,16 @@ func (w *Webcam) GetSupportedFormats() map[PixelFormat]string {
 	}
 
 	return result
+}
+
+// GetName returns the human-readable name of the device
+func (w *Webcam) GetName() (string, error) {
+	return getName(w.fd)
+}
+
+// GetBusInfo returns the location of the device in the system
+func (w *Webcam) GetBusInfo() (string, error) {
+	return getBusInfo(w.fd)
 }
 
 // Returns supported frame sizes for a given image format


### PR DESCRIPTION
From the kernel docs [here](https://www.kernel.org/doc/html/v5.5/media/uapi/v4l/vidioc-querycap.html#c.v4l2_capability)
> [card] Name of the device, a NUL-terminated UTF-8 string. For example: “Yoyodyne TV/FM”. One driver may support different brands or models of video hardware. This information is intended for users, for example in a menu of available devices. Since multiple TV cards of the same brand may be installed which are supported by the same driver, **this name should be combined with the character device file name (e. g. /dev/video2) or the bus_info string to avoid ambiguities**.

> [bus_info] Location of the device in the system, a NUL-terminated ASCII string. For example: “PCI:0000:05:06.0”. **This information is intended for users, to distinguish multiple identical devices**. If no such information is available the field must simply count the devices controlled by the driver (“platform:vivi-000”). The bus_info must start with “PCI:” for PCI boards, “PCIe:” for PCI Express boards, “usb-” for USB devices, “I2C:” for i2c devices, “ISA:” for ISA devices, “parport” for parallel port devices and “platform:” for platform devices.