### PR TITLE
Changed how the linux v4l2 file is opened

### DIFF
--- a/v4l2.go
+++ b/v4l2.go
@@ -499,7 +499,7 @@ func mmapQueryBuffer(fd uintptr, index uint32, length *uint32) (buffer []byte, e
 
 	*length = req.length
 
-	buffer, err = unix.Mmap(int(fd), int64(offset), int(req.length), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	buffer, err = unix.Mmap(int(fd), int64(offset), int(req.length), unix.PROT_READ, unix.MAP_SHARED)
 	return
 }
 

--- a/webcam.go
+++ b/webcam.go
@@ -5,6 +5,7 @@ package webcam
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"unsafe"
 
@@ -35,12 +36,14 @@ type Control struct {
 // capable to stream video
 func Open(path string) (*Webcam, error) {
 
-	handle, err := unix.Open(path, unix.O_RDWR|unix.O_NONBLOCK, 0666)
-	fd := uintptr(handle)
-
-	if fd < 0 || err != nil {
+	handle, err := unix.Open(path, unix.O_RDONLY|unix.O_NONBLOCK, 0666)
+	if err != nil {
 		return nil, err
 	}
+	if handle < 0 {
+		return nil, fmt.Errorf("failed to open %v", path)
+	}
+	fd := uintptr(handle)
 
 	supportsVideoCapture, supportsVideoStreaming, err := checkCapabilities(fd)
 


### PR DESCRIPTION
open the file as read only.
ioctl does not require files to be open for writing, and capturing a frame should be done read only. This should prevent blocking other processes including the camera produce in cases where the v4l2 device is actually a loopback device. 

Additionally fixed error handling around file opening to check for negative value prior to casting to unsigned.