### PR TITLE
Revert to read-write perms

### DIFF
--- a/v4l2.go
+++ b/v4l2.go
@@ -499,7 +499,7 @@ func mmapQueryBuffer(fd uintptr, index uint32, length *uint32) (buffer []byte, e
 
 	*length = req.length
 
-	buffer, err = unix.Mmap(int(fd), int64(offset), int(req.length), unix.PROT_READ, unix.MAP_SHARED)
+	buffer, err = unix.Mmap(int(fd), int64(offset), int(req.length), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
 	return
 }
 

--- a/webcam.go
+++ b/webcam.go
@@ -35,7 +35,7 @@ type Control struct {
 // Checks if device is a v4l2 device and if it is
 // capable to stream video
 func Open(path string) (*Webcam, error) {
-	handle, err := unix.Open(path, unix.O_RDONLY|unix.O_NONBLOCK, 0666)
+	handle, err := unix.Open(path, unix.O_RDWR|unix.O_NONBLOCK, 0666)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Noticed that `mmap` calls are failing for standard UVC V4L2 drivers (basic USB webcams) with the latest webcam commit. 

This PR reverts changes from [commit](https://github.com/blackjack/webcam/commit/f8ddb313107678fd170755be03878eadadd56a24) back to using `O_RDWR` flag for file open, and `PROT_READ | PROT_WRITE` flags for mmap calls.

This will allow the library to safely handle all standard v4l2 linux drivers. Even though we are not "writing", the v4l dev docs provide a [warning](https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/func-mmap.html) about the requirement for read-write when streaming.

@bpstark Could you provide more details about locking out other processes? It is my understanding that `unix.O_RDWR|unix.O_NONBLOCK` file flags do not attach a file lock. We would need to explicitly call `unix.Flock` for that.

## Testing
- Tested on basic usb webcams that use uvc v4l2 driver (on a Raspberry Pi).
- Happy to test out on other common v4l2 interfaces if that helps.
- @bpstark Any specific testing I should do on loopbacks?
